### PR TITLE
Avoid forcing the SLF4J implementation - leave that to user

### DIFF
--- a/raml-generator-core/pom.xml
+++ b/raml-generator-core/pom.xml
@@ -15,6 +15,13 @@
         <dependency>
             <groupId>org.raml</groupId>
             <artifactId>raml-parser</artifactId>
+            <exclusions>
+                <!-- do not force an SLF4J implementation -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/raml-maven-plugin-it/pom.xml
+++ b/raml-maven-plugin-it/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.justice.maven</groupId>
     <artifactId>raml-maven-plugin-it</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <!-- TODO add parent after extracting framewrok specific parent pom that does not contain raml-maven-plugin configuration-->
     <!-- remember to manually update version -->

--- a/raml-parser/pom.xml
+++ b/raml-parser/pom.xml
@@ -17,6 +17,13 @@
         <dependency>
             <groupId>org.raml</groupId>
             <artifactId>raml-parser</artifactId>
+            <exclusions>
+                <!-- do not force an SLF4J implementation -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi,
In order to avoid unnecessary dependencies, we need to exclude the SLF4J implementation forced by the upstream pom. This is a bug in the upstream raml.org project:
https://github.com/raml-org/raml-java-parser/pull/65

If we exclude the binding, the binding and the associated log4j dependency should not be imported.
