### PR TITLE
Clean up loggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>uk.gov.justice</groupId>
                 <artifactId>maven-common-bom</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/raml-generator-core/pom.xml
+++ b/raml-generator-core/pom.xml
@@ -21,6 +21,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/raml-maven-plugin-it/pom.xml
+++ b/raml-maven-plugin-it/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.justice.maven</groupId>
     <artifactId>raml-maven-plugin-it</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <!-- TODO add parent after extracting framewrok specific parent pom that does not contain raml-maven-plugin configuration-->
     <!-- remember to manually update version -->
@@ -93,8 +93,8 @@
         <dependencies>
             <dependency>
                 <groupId>uk.gov.justice</groupId>
-                <artifactId>common-bom</artifactId>
-                <version>1.6.10</version>
+                <artifactId>maven-common-bom</artifactId>
+                <version>1.5.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/raml-maven-plugin/pom.xml
+++ b/raml-maven-plugin/pom.xml
@@ -115,6 +115,15 @@
             <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/raml-parser/pom.xml
+++ b/raml-parser/pom.xml
@@ -23,6 +23,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -40,6 +44,16 @@
             <groupId>uk.gov.justice.maven</groupId>
             <artifactId>raml-for-testing-io</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Correctly specify dependencies for logging to improve output from plugin.